### PR TITLE
remove unnecessary import

### DIFF
--- a/components/plugin/src/miniboxing/plugin/metadata/InteropDefinitions.scala
+++ b/components/plugin/src/miniboxing/plugin/metadata/InteropDefinitions.scala
@@ -15,7 +15,6 @@ package metadata
 
 import scala.tools.nsc.plugins.PluginComponent
 import scala.collection.immutable.ListMap
-import sun.org.mozilla.javascript.internal.FunctionObject
 
 trait InteropDefinitions {
   this: PluginComponent =>


### PR DESCRIPTION
The import of `import sun.org.mozilla.javascript.internal.FunctionObject` is unnecessary. Moreover, it breaks compilation against JDK 8.
