### PR TITLE
Issue #167

### DIFF
--- a/components/plugin/src/miniboxing/plugin/Minibox.scala
+++ b/components/plugin/src/miniboxing/plugin/Minibox.scala
@@ -345,6 +345,7 @@ class Minibox(val global: Global) extends Plugin with ScalacVersion {
                                "http://scala-miniboxing.org/2014/10/21/miniboxing-warnings.html.")
         case "warn-off" =>
           flag_strict_warnings = false
+          flag_warn_mbarrays = false
         case "warn-all" =>
           flag_strict_warnings = true
           flag_strict_warnings_outside = true

--- a/components/plugin/src/miniboxing/plugin/Minibox.scala
+++ b/components/plugin/src/miniboxing/plugin/Minibox.scala
@@ -154,6 +154,7 @@ trait MiniboxInjectComponent extends
   def flag_two_way: Boolean
   def flag_strict_warnings: Boolean
   def flag_strict_warnings_outside: Boolean
+  def flag_warn_mbarrays: Boolean
   def flag_create_local_specs: Boolean
   def flag_constructor_spec: Boolean
 }
@@ -311,6 +312,7 @@ class Minibox(val global: Global) extends Plugin with ScalacVersion {
   var flag_create_local_specs = true
   var flag_strict_warnings = true
   var flag_strict_warnings_outside = false
+  var flag_warn_mbarrays = true
   var flag_rewire_functionX_application = true
   var flag_rewire_mbarray = true
   var flag_constructor_spec = true
@@ -346,6 +348,8 @@ class Minibox(val global: Global) extends Plugin with ScalacVersion {
         case "warn-all" =>
           flag_strict_warnings = true
           flag_strict_warnings_outside = true
+        case "warn-mbarrays-off" =>
+          flag_warn_mbarrays = false
         case "mark-all" =>
           flag_mark_all = true
 
@@ -399,6 +403,7 @@ class Minibox(val global: Global) extends Plugin with ScalacVersion {
           flag_create_local_specs = false
           flag_strict_warnings = false
           flag_strict_warnings_outside = false
+          flag_warn_mbarrays = false
           flag_rewire_mbarray = false
           flag_constructor_spec = false
         case _ =>
@@ -408,11 +413,12 @@ class Minibox(val global: Global) extends Plugin with ScalacVersion {
   }
 
   override val optionsHelp: Option[String] = Some(Seq(
-    s"  -P:${name}:warn-off  do not show performance and specialization warnings for your code",
-    s"  -P:${name}:warn-all  show cross-project warnings, aka warn for the libraries as well",
-    s"  -P:${name}:hijack    hijack the @specialized(...) notation for miniboxing",
-    s"  -P:${name}:mark-all  implicitly add @miniboxed annotations to all type parameters",
-    s"  -P:${name}:log       log miniboxing signature transformations").mkString("\n"))
+    s"  -P:${name}:warn-off          do not show performance and specialization warnings for your code",
+    s"  -P:${name}:warn-all          show cross-project warnings, aka warn for the libraries as well",
+    s"  -P:${name}:warn-mbarrys-off  do not show warnings suggesting use of MbArray instead of Array",
+    s"  -P:${name}:hijack            hijack the @specialized(...) notation for miniboxing",
+    s"  -P:${name}:mark-all          implicitly add @miniboxed annotations to all type parameters",
+    s"  -P:${name}:log               log miniboxing signature transformations").mkString("\n"))
 
   private object HijackPhase extends HijackComponent {
     val global: Minibox.this.global.type = Minibox.this.global
@@ -526,6 +532,7 @@ class Minibox(val global: Global) extends Plugin with ScalacVersion {
     def flag_create_local_specs = Minibox.this.flag_create_local_specs
     def flag_strict_warnings = Minibox.this.flag_strict_warnings
     def flag_strict_warnings_outside = Minibox.this.flag_strict_warnings_outside
+    def flag_warn_mbarrays = Minibox.this.flag_warn_mbarrays
     def flag_constructor_spec = Minibox.this.flag_constructor_spec
 
     var mboxInjectPhase : StdPhase = _

--- a/components/plugin/src/miniboxing/plugin/Minibox.scala
+++ b/components/plugin/src/miniboxing/plugin/Minibox.scala
@@ -128,6 +128,7 @@ trait MiniboxInjectComponent extends
     PluginComponent
     with MiniboxLogging
     with MiniboxDefinitions
+    with MbArrayDefinitions
     with MbReflectionDefinitions
     with MiniboxNameUtils
     with MiniboxMetadata

--- a/components/plugin/src/miniboxing/plugin/MiniboxLogging.scala
+++ b/components/plugin/src/miniboxing/plugin/MiniboxLogging.scala
@@ -19,12 +19,11 @@ trait MiniboxLogging {
 
   import global._
 
-  def suboptimalCodeWarning(pos: Position, msg: String, isSymbolGenericAnnotated: Boolean = false, inLibrary: Boolean = false) = {
-      if (flag_strict_warnings && (pos != NoPosition) && !isSymbolGenericAnnotated)
-        if (!inLibrary || flag_strict_warnings_outside)
-          global.reporter.warning(pos, msg)
-  }
-
+  def suboptimalCodeWarning(pos: Position, msg: String, isSymbolGenericAnnotated: Boolean = false, inLibrary: Boolean = false) =
+    if (flag_strict_warnings && (pos != NoPosition) && !isSymbolGenericAnnotated)
+      if (!inLibrary || flag_strict_warnings_outside)
+        global.reporter.warning(pos, msg)
+        
   def global_log(msg: => String) = if (settings.log.value.contains(phaseName)) global.log(msg)
   def log(msg: => Any) = if (flag_log) println(msg.toString) // TODO: Need to adapt tests to output miniboxing messages
   def mblog(msg: => Any) = log(msg)

--- a/components/plugin/src/miniboxing/plugin/metadata/MbArrayDefinitions.scala
+++ b/components/plugin/src/miniboxing/plugin/metadata/MbArrayDefinitions.scala
@@ -26,10 +26,12 @@ trait MbArrayDefinitions {
   lazy val MbArrayModule  = global.rootMirror.getRequiredModule("scala.MbArray")
   lazy val MbArray_apply  = definitions.getMember(MbArrayClass, newTermName("apply"))
   lazy val MbArray_update = definitions.getMember(MbArrayClass, newTermName("update"))
+  lazy val MbArray_length = definitions.getMember(MbArrayClass, newTermName("length"))
   lazy val MbArray_empty  = definitions.getMember(MbArrayModule, newTermName("empty"))
   lazy val MbArray_clone  = definitions.getMember(MbArrayModule, newTermName("clone")).
                               // filter Object.clone out, we don't want that:
                               alternatives.find(_.owner == MbArrayModule.moduleClass).get
+  lazy val MbArray_arraycopy  = definitions.getMember(MbArrayModule, newTermName("arraycopy"))                      
 
   // optimized alternatives:
   lazy val MbArrayOpts    = global.rootMirror.getRequiredModule("miniboxing.runtime.array.MbArrayOpts")
@@ -45,5 +47,13 @@ trait MbArrayDefinitions {
               DoubleClass -> definitions.getMember(MbArrayOpts, newTermName("mbArray_empty_D"))),
         MbArray_clone ->
           Map(LongClass   -> definitions.getMember(MbArrayOpts, newTermName("mbArray_clone_J")),
-              DoubleClass -> definitions.getMember(MbArrayOpts, newTermName("mbArray_clone_D"))))
+              DoubleClass -> definitions.getMember(MbArrayOpts, newTermName("mbArray_clone_D")))) 
+              
+  def isSymbolMbArrayMethod(sym: Symbol): Boolean = 
+    sym.equals(MbArray_apply) || 
+    sym.equals(MbArray_update) ||
+    sym.equals(MbArray_length) ||
+    sym.equals(MbArray_empty) || 
+    sym.equals(MbArray_clone) ||
+    sym.equals(MbArray_arraycopy)
 }

--- a/components/plugin/src/miniboxing/plugin/metadata/MiniboxMetadataAddons.scala
+++ b/components/plugin/src/miniboxing/plugin/metadata/MiniboxMetadataAddons.scala
@@ -49,6 +49,10 @@ trait MiniboxMetadataAddons {
       sym hasAnnotation GenericClass
     }
     def isField = sym.isValue && !sym.isMethod
+    def isMbArrayMethod: Boolean = isSymbolMbArrayMethod(sym)
+    def isArray: Boolean = sym.equals(ArrayClass)
+    def isImplicitlyPredefMethod: Boolean = isPredefMemberNamed(sym, nme.implicitly)
+    def isArrowAssocPredefMethod: Boolean = isPredefMemberNamed(sym, nme.Predef.newName("ArrowAssoc"))
 
     private def tweakedKind = if (sym.isTrait) if (flagdata.classStemTraitFlag(sym)) "trait" else "class" else sym.kindString
     private def tweakedName = if (sym.hasMeaninglessName) sym.owner.decodedName + sym.idString else sym.nameString

--- a/components/plugin/src/miniboxing/plugin/metadata/MiniboxMetadataAddons.scala
+++ b/components/plugin/src/miniboxing/plugin/metadata/MiniboxMetadataAddons.scala
@@ -15,6 +15,7 @@ package metadata
 
 import scala.collection.immutable.ListMap
 import language.implicitConversions
+import scala.reflect.NameTransformer
 
 trait MiniboxMetadataAddons {
   self: MiniboxInjectComponent =>
@@ -54,7 +55,10 @@ trait MiniboxMetadataAddons {
     def isImplicitlyPredefMethod: Boolean = isPredefMemberNamed(sym, nme.implicitly)
     def isCastSymbol: Boolean = definitions.isCastSymbol(sym)
     def isIsInstanceOfAnyMethod: Boolean = sym == Any_isInstanceOf
-    def isArrowAssocMethod: Boolean = isPredefMemberNamed(sym, nme.Predef.newName("ArrowAssoc")) || (sym.owner == getMemberClass(PredefModule, TypeName("ArrowAssoc")) && sym.name == nme.MINGT)
+    def isArrowAssocMethod: Boolean = 
+      isPredefMemberNamed(sym, newTermName("ArrowAssoc")) || 
+      isPredefMemberNamed(sym, newTermName("any2ArrowAssoc")) || 
+      (sym.owner == getMemberClass(PredefModule, newTermName("ArrowAssoc")) && sym.name == newTermName(NameTransformer.encode("->")))
 
     private def tweakedKind = if (sym.isTrait) if (flagdata.classStemTraitFlag(sym)) "trait" else "class" else sym.kindString
     private def tweakedName = if (sym.hasMeaninglessName) sym.owner.decodedName + sym.idString else sym.nameString

--- a/components/plugin/src/miniboxing/plugin/metadata/MiniboxMetadataAddons.scala
+++ b/components/plugin/src/miniboxing/plugin/metadata/MiniboxMetadataAddons.scala
@@ -50,9 +50,11 @@ trait MiniboxMetadataAddons {
     }
     def isField = sym.isValue && !sym.isMethod
     def isMbArrayMethod: Boolean = isSymbolMbArrayMethod(sym)
-    def isArray: Boolean = sym.equals(ArrayClass)
+    def isArray: Boolean = sym == ArrayClass
     def isImplicitlyPredefMethod: Boolean = isPredefMemberNamed(sym, nme.implicitly)
-    def isArrowAssocPredefMethod: Boolean = isPredefMemberNamed(sym, nme.Predef.newName("ArrowAssoc"))
+    def isCastSymbol: Boolean = definitions.isCastSymbol(sym)
+    def isIsInstanceOfAnyMethod: Boolean = sym == Any_isInstanceOf
+    def isArrowAssocMethod: Boolean = isPredefMemberNamed(sym, nme.Predef.newName("ArrowAssoc")) || (sym.owner == getMemberClass(PredefModule, TypeName("ArrowAssoc")) && sym.name == nme.MINGT)
 
     private def tweakedKind = if (sym.isTrait) if (flagdata.classStemTraitFlag(sym)) "trait" else "class" else sym.kindString
     private def tweakedName = if (sym.hasMeaninglessName) sym.owner.decodedName + sym.idString else sym.nameString

--- a/components/plugin/src/miniboxing/plugin/metadata/MiniboxMetadataUtils.scala
+++ b/components/plugin/src/miniboxing/plugin/metadata/MiniboxMetadataUtils.scala
@@ -126,7 +126,7 @@ trait MiniboxMetadataUtils {
 
     def fromTargsAllTargs(pos: Position, instantiation: List[(Symbol, Type)], currentOwner: Symbol, pspec: PartialSpec = Map.empty): PartialSpec = {
       def useMbArrayInsteadOfArrayWarning(p: Symbol): Unit = 
-        suboptimalCodeWarning(pos, "Use MbArray instead of Array and benefit from miniboxing specialization", p.isGenericAnnotated)
+        if (flag_warn_mbarrays) suboptimalCodeWarning(pos, "Use MbArray instead of Array and benefit from miniboxing specialization", p.isGenericAnnotated)
         
       def primitive(p: Symbol, spec: SpecInfo): (Symbol, SpecInfo) = {
         if (!metadata.miniboxedTParamFlag(p) && !isUselessWarning(p.owner) && !p.hasAnnotation(SpecializedClass))

--- a/tests/correctness/resources/miniboxing/tests/compile/SI-4012-2.check
+++ b/tests/correctness/resources/miniboxing/tests/compile/SI-4012-2.check
@@ -1,9 +1,3 @@
 newSource1.scala:6: error: Using named super is not supported in miniboxed classes. For a workaround, please see https://github.com/miniboxing/miniboxing-plugin/issues/166:
   super[Super].superb // okay
                ^
-newSource1.scala:7: warning: The class Super would benefit from miniboxing type parameter A, since it is instantiated by a primitive type.
-  super.superb        // okay
-        ^
-newSource1.scala:8: warning: The class Super would benefit from miniboxing type parameter A, since it is instantiated by a primitive type.
-  override def superb: Int = super.superb // okay
-                                   ^

--- a/tests/correctness/resources/miniboxing/tests/compile/SI-4012-2.check
+++ b/tests/correctness/resources/miniboxing/tests/compile/SI-4012-2.check
@@ -1,3 +1,9 @@
 newSource1.scala:6: error: Using named super is not supported in miniboxed classes. For a workaround, please see https://github.com/miniboxing/miniboxing-plugin/issues/166:
   super[Super].superb // okay
                ^
+newSource1.scala:7: warning: Although the type parameter A of class Super is specialized, miniboxing and specialization communicate among themselves by boxing (thus, inefficiently) on all classes other than as FunctionX and TupleX. If you want to maximize performance, consider switching from specialization to miniboxing: '@miniboxed T':
+  super.superb        // okay
+        ^
+newSource1.scala:8: warning: Although the type parameter A of class Super is specialized, miniboxing and specialization communicate among themselves by boxing (thus, inefficiently) on all classes other than as FunctionX and TupleX. If you want to maximize performance, consider switching from specialization to miniboxing: '@miniboxed T':
+  override def superb: Int = super.superb // okay
+                                   ^

--- a/tests/correctness/resources/miniboxing/tests/compile/gh-bug-105.check
+++ b/tests/correctness/resources/miniboxing/tests/compile/gh-bug-105.check
@@ -1,1 +1,5 @@
+newSource1.scala:11: warning: Use MbArray instead of Array and benefit from miniboxing specialization
+    array = new Array[Int](16)
+            ^
+
 init() called.

--- a/tests/correctness/resources/miniboxing/tests/compile/gh-bug-167-mbarray-warn-off.check
+++ b/tests/correctness/resources/miniboxing/tests/compile/gh-bug-167-mbarray-warn-off.check
@@ -1,3 +1,6 @@
+newSource1.scala:34: warning: Although the type parameter S of method Test.zoo is specialized, miniboxing and specialization communicate among themselves by boxing (thus, inefficiently) on all classes other than as FunctionX and TupleX. If you want to maximize performance, consider switching from specialization to miniboxing: '@miniboxed T':
+  zoo[Int](3)
+     ^
 newSource1.scala:36: warning: Although the type parameter S of method Test.zoo is specialized, miniboxing and specialization communicate among themselves by boxing (thus, inefficiently) on all classes other than as FunctionX and TupleX. If you want to maximize performance, consider switching from specialization to miniboxing: '@miniboxed T':
    def zar[@miniboxed S](t: S) = zoo[S](t)
                                  ^

--- a/tests/correctness/resources/miniboxing/tests/compile/gh-bug-167-mbarray-warn-off.check
+++ b/tests/correctness/resources/miniboxing/tests/compile/gh-bug-167-mbarray-warn-off.check
@@ -1,6 +1,4 @@
-newSource1.scala:13: warning: Use MbArray instead of Array and benefit from miniboxing specialization
-  def newArray = new C(new Array[Int](10))
-                       ^
 newSource1.scala:36: warning: Although the type parameter S of method Test.zoo is specialized, miniboxing and specialization communicate among themselves by boxing (thus, inefficiently) on all classes other than as FunctionX and TupleX. If you want to maximize performance, consider switching from specialization to miniboxing: '@miniboxed T':
    def zar[@miniboxed S](t: S) = zoo[S](t)
                                  ^
+

--- a/tests/correctness/resources/miniboxing/tests/compile/gh-bug-167-mbarray-warn-off.flags
+++ b/tests/correctness/resources/miniboxing/tests/compile/gh-bug-167-mbarray-warn-off.flags
@@ -1,0 +1,1 @@
+-P:minibox:warn-all -P:minibox:warn-mbarrays-off

--- a/tests/correctness/resources/miniboxing/tests/compile/gh-bug-167-mbarray-warn-off.scala
+++ b/tests/correctness/resources/miniboxing/tests/compile/gh-bug-167-mbarray-warn-off.scala
@@ -1,0 +1,38 @@
+import reflect.ClassTag
+
+class C[@miniboxed T](val arr: MbArray[T]) {
+  // empty:
+  def this(size: Int) = this(MbArray.empty[T](size))
+  // clone:
+  def this(a: Array[T]) = this(MbArray.clone[T](a))
+
+  // arraycopy:
+  MbArray.arraycopy(arr, 0, arr, 0, 0)
+
+  // Array:
+  def newArray = new C(new Array[Int](10))
+
+  // implicitly:
+  implicit val x = 3
+  implicitly[Int]
+
+  // ClassTag:
+  implicitly[ClassTag[Int]]
+
+  // asInstanceOf/isInstanceOf:
+  def foo(x: Any) =
+    if (x.isInstanceOf[Int])
+      println(x.asInstanceOf[Int])
+
+  // arrowassoc:
+  2 -> 3
+}
+
+object Test {
+  def zoo[@specialized S](t: S) = t
+
+  zoo[Int](3)
+
+  def zar[@miniboxed S](t: S) = zoo[S](t)
+}
+

--- a/tests/correctness/resources/miniboxing/tests/compile/gh-bug-167.check
+++ b/tests/correctness/resources/miniboxing/tests/compile/gh-bug-167.check
@@ -1,0 +1,15 @@
+newSource1.scala:13: warning: Use MbArray instead of Array and benefit from miniboxing specialization
+  def newArray = new C(new Array[Int](10))
+                       ^
+newSource1.scala:24: warning: The method scala.Any.isInstanceOf would benefit from miniboxing type parameter T0, since it is instantiated by a primitive type.
+    if (x.isInstanceOf[Int])
+          ^
+newSource1.scala:25: warning: The method scala.Any.asInstanceOf would benefit from miniboxing type parameter T0, since it is instantiated by a primitive type.
+      println(x.asInstanceOf[Int])
+                ^
+newSource1.scala:28: warning: The method scala.Predef.ArrowAssoc.-> would benefit from miniboxing type parameter B, since it is instantiated by a primitive type.
+  2 -> 3
+    ^
+newSource1.scala:36: warning: The method Test.zoo would benefit from miniboxing type parameter S, since it is instantiated by miniboxed type parameter S of method zar.
+  def zar[@miniboxed S](t: S) = zoo[S](t)
+                                ^

--- a/tests/correctness/resources/miniboxing/tests/compile/gh-bug-167.check
+++ b/tests/correctness/resources/miniboxing/tests/compile/gh-bug-167.check
@@ -1,6 +1,9 @@
 newSource1.scala:13: warning: Use MbArray instead of Array and benefit from miniboxing specialization
   def newArray = new C(new Array[Int](10))
                        ^
+newSource1.scala:34: warning: Although the type parameter S of method Test.zoo is specialized, miniboxing and specialization communicate among themselves by boxing (thus, inefficiently) on all classes other than as FunctionX and TupleX. If you want to maximize performance, consider switching from specialization to miniboxing: '@miniboxed T':
+  zoo[Int](3)
+     ^
 newSource1.scala:36: warning: Although the type parameter S of method Test.zoo is specialized, miniboxing and specialization communicate among themselves by boxing (thus, inefficiently) on all classes other than as FunctionX and TupleX. If you want to maximize performance, consider switching from specialization to miniboxing: '@miniboxed T':
    def zar[@miniboxed S](t: S) = zoo[S](t)
                                  ^

--- a/tests/correctness/resources/miniboxing/tests/compile/gh-bug-167.flags
+++ b/tests/correctness/resources/miniboxing/tests/compile/gh-bug-167.flags
@@ -1,0 +1,1 @@
+-P:minibox:warn-all

--- a/tests/correctness/resources/miniboxing/tests/compile/gh-bug-167.scala
+++ b/tests/correctness/resources/miniboxing/tests/compile/gh-bug-167.scala
@@ -1,0 +1,38 @@
+import reflect.ClassTag
+
+class C[@miniboxed T](val arr: MbArray[T]) {
+  // empty:
+  def this(size: Int) = this(MbArray.empty[T](size))
+  // clone:
+  def this(a: Array[T]) = this(MbArray.clone[T](a))
+
+  // arraycopy:
+  MbArray.arraycopy(arr, 0, arr, 0, 0)
+
+  // Array:
+  def newArray = new C(new Array[Int](10))
+
+  // implicitly:
+  implicit val x = 3
+  implicitly[Int]
+
+  // ClassTag:
+  implicitly[ClassTag[Int]]
+
+  // asInstanceOf/isInstanceOf:
+  def foo(x: Any) =
+    if (x.isInstanceOf[Int])
+      println(x.asInstanceOf[Int])
+
+  // arrowassoc:
+  2 -> 3
+}
+
+object Test {
+  def zoo[@specialized S](t: S) = t
+
+  zoo[Int](3)
+
+  def zar[@miniboxed S](t: S) = zoo[S](t)
+}
+

--- a/tests/correctness/resources/miniboxing/tests/compile/mb_array_04.check
+++ b/tests/correctness/resources/miniboxing/tests/compile/mb_array_04.check
@@ -1,3 +1,9 @@
+newSource1.scala:8: warning: Use MbArray instead of Array and benefit from miniboxing specialization
+  val mba1 = MbArray.clone(new Array[Int](10))
+                           ^
+newSource1.scala:9: warning: Use MbArray instead of Array and benefit from miniboxing specialization
+  val mba2 = MbArray.clone(new Array[Double](10))
+                           ^
 newSource1.scala:13: warning: The following code instantiating an `MbArray` object cannot be optimized since the type argument is not a primitive type (like Int), a miniboxed type parameter or a subtype of AnyRef. This means that primitive types could end up boxed:
   val mba4 = MbArray.clone(new Array[Any](10))
                      ^

--- a/tests/correctness/resources/miniboxing/tests/compile/mb_array_slowdown_exec.check
+++ b/tests/correctness/resources/miniboxing/tests/compile/mb_array_slowdown_exec.check
@@ -1,3 +1,6 @@
+newSource1.scala:43: warning: Use MbArray instead of Array and benefit from miniboxing specialization
+    val c = new Array[Int](len)
+            ^
 class [Ljava.lang.Object;
 class miniboxing.runtime.array.MbArray_J
 class [I

--- a/tests/correctness/resources/miniboxing/tests/compile/mb_array_vec_example.check
+++ b/tests/correctness/resources/miniboxing/tests/compile/mb_array_vec_example.check
@@ -1,3 +1,6 @@
+newSource1.scala:24: warning: Use MbArray instead of Array and benefit from miniboxing specialization
+  val doubleData: Array[Double] = new Array[Double](size)
+                                  ^
 [[syntax trees at end of            minibox-commit]] // newSource1.scala
 package respec {
   abstract trait Vec[@miniboxed T] extends Object {


### PR DESCRIPTION
- Dont show useless warnings for `-P:minibox:warn-all`
  - MbArray methods
  - Creating new Array
  - Predef.implicitly
  - isInstanceOf
  - asInstanceOf
  - arrowAssoc
- Change content of warning shown when both 'miniboxed' and 'specialized' annotations are used
- Don't show warning if type argument is primitive type and type parameter in definition is annotated with 'specialized'
- Warn that MbArray should be used instead of Array when Array is created + added flag `-P:minibox:warn-mbarrays-off` to turn this warning off
