### PR TITLE
Convert Float/Double to Long more accurately

### DIFF
--- a/components/runtime/src/miniboxing/runtime/MiniboxConversions.java
+++ b/components/runtime/src/miniboxing/runtime/MiniboxConversions.java
@@ -82,11 +82,11 @@ public class MiniboxConversions {
   }
 
   public final static long float2minibox(float f) {
-    return (long) Float.floatToIntBits(f);
+    return (long) Float.floatToRawIntBits(f);
   }
 
   public final static long double2minibox(double f) {
-    return (long) Double.doubleToLongBits(f);
+    return (long) Double.doubleToRawLongBits(f);
   }
 
   /**
@@ -170,9 +170,9 @@ public class MiniboxConversions {
       case MiniboxConstants.INT:
         return (java.lang.Integer)a;
       case MiniboxConstants.FLOAT:
-        return Float.floatToIntBits((java.lang.Float)a);
+        return Float.floatToRawIntBits((java.lang.Float)a);
       case MiniboxConstants.DOUBLE:
-        return Double.doubleToLongBits((java.lang.Double)a);
+        return Double.doubleToRawLongBits((java.lang.Double)a);
       default:
         return (java.lang.Long)a;
     }


### PR DESCRIPTION
Warning: don't merge yet.

Double.doubleToLongBits and Float.floatToIntBits are documented to not be fully invertible, because they take extra effort to collapse different NaN values together. Hence, it appears miniboxing could conceivably interfere with (admittedly strange) code that distinguishes different NaNs (say, code also casting across Long and Double, like in some JavaScript engines). Using the `Raw` variants prevents the issue (and has no overhead at all).

This is untested, done from the browser, and I'm guessing that the goal of this code is to "box" primitives as Long to pass them to the specialized-for-all-primitives version of the interface.

There are more uses of these primitives to review and probably fix.
https://github.com/miniboxing/miniboxing-plugin/search?q=doubleToLongBits&type=Code&utf8=%E2%9C%93
