### PR TITLE
Fix the bug that several miniboxed numerics do minus when called for plus

### DIFF
--- a/components/runtime/src/miniboxing/runtime/math/MiniboxedFractional.scala
+++ b/components/runtime/src/miniboxing/runtime/math/MiniboxedFractional.scala
@@ -42,7 +42,7 @@ object MiniboxedFractional {
           def div(x: T, y: T): T = frac.div(x, y)
 
           val extractNumeric: Numeric[T] = frac
-          def plus(x: T, y: T): T = frac.minus(x, y)
+          def plus(x: T, y: T): T = frac.plus(x, y)
           def minus(x: T, y: T): T = frac.minus(x, y)
           def times(x: T, y: T): T = frac.times(x, y)
           def negate(x: T): T = frac.negate(x)

--- a/components/runtime/src/miniboxing/runtime/math/MiniboxedFractionalBridge.scala
+++ b/components/runtime/src/miniboxing/runtime/math/MiniboxedFractionalBridge.scala
@@ -23,7 +23,7 @@ object MiniboxedFractionalBridge {
       def div(x: T, y: T): T = _frac.div(x, y)
       
       val extractNumeric: Numeric[T] = _frac
-      def plus(x: T, y: T): T = _frac.minus(x, y)
+      def plus(x: T, y: T): T = _frac.plus(x, y)
       def minus(x: T, y: T): T = _frac.minus(x, y)
       def times(x: T, y: T): T = _frac.times(x, y)
       def negate(x: T): T = _frac.negate(x)

--- a/components/runtime/src/miniboxing/runtime/math/MiniboxedIntegral.scala
+++ b/components/runtime/src/miniboxing/runtime/math/MiniboxedIntegral.scala
@@ -50,7 +50,7 @@ object MiniboxedIntegral {
           def rem(x: T, y: T): T = int.rem(x, y)
 
           val extractNumeric: Numeric[T] = int
-          def plus(x: T, y: T): T = int.minus(x, y)
+          def plus(x: T, y: T): T = int.plus(x, y)
           def minus(x: T, y: T): T = int.minus(x, y)
           def times(x: T, y: T): T = int.times(x, y)
           def negate(x: T): T = int.negate(x)

--- a/components/runtime/src/miniboxing/runtime/math/MiniboxedIntegralBridge.scala
+++ b/components/runtime/src/miniboxing/runtime/math/MiniboxedIntegralBridge.scala
@@ -24,7 +24,7 @@ object MiniboxedIntegralBridge {
       def rem(x: T, y: T): T = _int.rem(x, y)
       
       val extractNumeric: Numeric[T] = _int
-      def plus(x: T, y: T): T = _int.minus(x, y)
+      def plus(x: T, y: T): T = _int.plus(x, y)
       def minus(x: T, y: T): T = _int.minus(x, y)
       def times(x: T, y: T): T = _int.times(x, y)
       def negate(x: T): T = _int.negate(x)


### PR DESCRIPTION
For example, the following code would return `1.0` instead of `3.0`:

```
object Main {
  def add[T](a: T, b: T)(implicit num: MiniboxedFractional[T]) = num.plus(a, b)
  def main(args: Array[String]) {
    println(add(BigDecimal(2.0), BigDecimal(1.0)))
  }
}
```
